### PR TITLE
LSHZ-2DTM underrated armor fix

### DIFF
--- a/src/armor.js
+++ b/src/armor.js
@@ -1030,13 +1030,13 @@ class Armor {
             if (serverItem._id === "5d6d3716a4b9361bc8618872") {
                 serverItem._props.Durability = 20;
                 serverItem._props.MaxDurability = serverItem._props.Durability;
-                serverItem._props.armorClass = 4;
+                serverItem._props.armorClass = 5;
                 serverItem._props.speedPenaltyPercent = -1.7;
                 serverItem._props.mousePenalty = 0;
                 serverItem._props.weaponErgonomicPenalty = -1.7;
                 serverItem._props.BluntThroughput = 0.2;
                 serverItem._props.DeafStrength = "High";
-                serverItem._props.ArmorMaterial = 'UHMWPE';
+                serverItem._props.ArmorMaterial = 'Aramid';
                 serverItem._props.Weight = 3.4;
             }
             //// Class 5 ////
@@ -1460,7 +1460,7 @@ class Armor {
             if (serverItem._id === "5d6d3be5a4b9361bc73bc763") {
                 serverItem._props.Durability = 60;
                 serverItem._props.MaxDurability = serverItem._props.Durability;
-                serverItem._props.armorClass = 4;
+                serverItem._props.armorClass = 5;
                 serverItem._props.speedPenaltyPercent = -0.6;
                 serverItem._props.mousePenalty = 0;
                 serverItem._props.weaponErgonomicPenalty = -0.6;

--- a/src/armor.ts
+++ b/src/armor.ts
@@ -1039,13 +1039,13 @@ export class Armor {
             if (serverItem._id === "5d6d3716a4b9361bc8618872") {
                 serverItem._props.Durability = 20;
                 serverItem._props.MaxDurability = serverItem._props.Durability;
-                serverItem._props.armorClass = 4;
+                serverItem._props.armorClass = 5;
                 serverItem._props.speedPenaltyPercent = -1.7;
                 serverItem._props.mousePenalty = 0;
                 serverItem._props.weaponErgonomicPenalty = -1.7;
                 serverItem._props.BluntThroughput = 0.2;
                 serverItem._props.DeafStrength = "High";
-                serverItem._props.ArmorMaterial = 'UHMWPE';
+                serverItem._props.ArmorMaterial = 'Aramid';
                 serverItem._props.Weight = 3.4;
             }
             //// Class 5 ////
@@ -1469,7 +1469,7 @@ export class Armor {
             if (serverItem._id === "5d6d3be5a4b9361bc73bc763") {
                 serverItem._props.Durability = 60;
                 serverItem._props.MaxDurability = serverItem._props.Durability;
-                serverItem._props.armorClass = 4;
+                serverItem._props.armorClass = 5;
                 serverItem._props.speedPenaltyPercent = -0.6;
                 serverItem._props.mousePenalty = 0;
                 serverItem._props.weaponErgonomicPenalty = -0.6;


### PR DESCRIPTION
According to technical documentation(which available on manufacturer website) BNTI LSHZ-D2TM helmet and aventail add-on have more armor in real life, than in this mode.

Proposed changes:
BNTI LSHZ-D2TM helmet:
- Armor rating from 4 to 5(which is GOST 2)
- Armor type changed from UHMWPE to Aramid

BNTI LSHZ-D2TM aventail:
- Armor rating from 4 to 5(which is GOST 2)
- Armor type changed from UHMWPE to Aramid

Reasons:
- "Корпус шлема обеспечивает уровень **защиты головы** по **2** классу ГОСТ Р 50744-95, лица по 1 или 2 классу, **шеи** по **2** классу защиты."
- "Защитная структура **корпуса** и **бармицы** изделия состоит из дискретно-тканевых материалов на основе **арамидных нитей**."

Source links: 
- http://www.bnti.ru/des.asp?itm=6522&tbl=08.02.02.&p=1