### PR TITLE
SVM special slot compatibility

### DIFF
--- a/src/items/gear.ts
+++ b/src/items/gear.ts
@@ -24,6 +24,11 @@ export class Gear {
         this.itemDB()["65e080be269cbd5c5005e529"]._props.Slots.forEach(slot => {
             slot._props.filters[0].Filter.push("5672cb724bdc2dc2088b456b", "590a3efd86f77437d351a25b");
         });
+        if(this.itemDB()["a8edfb0bce53d103d3f62b9b"]) {
+            this.itemDB()["a8edfb0bce53d103d3f62b9b"]._props.Slots.forEach(slot => {
+                slot._props.filters[0].Filter.push("5672cb724bdc2dc2088b456b", "590a3efd86f77437d351a25b");
+            });
+        }
     }
 
     public loadGearConflicts() {


### PR DESCRIPTION
Adds a check if the SVM pockets exist and adds the gas analyzer and geiger counter to the filters if they do