### PR TITLE
Ignore accuracy value for Gunsmith weapons

### DIFF
--- a/src/traders/quests.ts
+++ b/src/traders/quests.ts
@@ -174,6 +174,10 @@ export class Quests {
                     condition["durability"].value = 1;
                     condition["durability"].compareMethod = ">=";
                 }
+                if (condition["baseAccuracy"]) {
+                    condition["baseAccuracy"].value = -1;
+                    condition["baseAccuracy"].compareMethod = ">=";
+                }
             }
 
             let id = this.questDB()[i]._id;


### PR DESCRIPTION
This patch offsets the accuracy buffs given to suppressors by Realism. This is primarily for Gunsmith 21 where several suppressors will make the M700 "too accurate" to be turned in, even the Gemtech ONE, which is part of the "intended" build from the quest image.

In my testing this does not negatively impact any quests.